### PR TITLE
Implement outreach automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and fill in your credentials
+GMAIL_ADDRESS=
+GMAIL_PASSWORD=
+DEEPSEEK_API_KEY=
+SERPAPI_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Environment variables
+.env
+
+# Output files
+lawyers.csv
+sent.csv
+
+# Python cache
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# X
+# Painsnap Outreach Agent
+
+Automated tool to scrape personal injury lawyers in Ontario and send personalized outreach emails.
+
+The project uses DeepSeek's API to rewrite outreach templates into personalized messages. Configure the API key in `.env` as `DEEPSEEK_API_KEY`.

--- a/email_sender.py
+++ b/email_sender.py
@@ -1,0 +1,16 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+
+GMAIL_ADDRESS = os.getenv("GMAIL_ADDRESS")
+GMAIL_PASSWORD = os.getenv("GMAIL_PASSWORD")
+
+
+def send_email(to_address: str, body: str, subject: str = "Injury Client Referrals – Painsnap.tech") -> None:
+    msg = MIMEText(body)
+    msg["Subject"] = subject
+    msg["From"] = GMAIL_ADDRESS
+    msg["To"] = to_address
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+        server.login(GMAIL_ADDRESS, GMAIL_PASSWORD)
+        server.sendmail(GMAIL_ADDRESS, [to_address], msg.as_string())

--- a/gpt_generator.py
+++ b/gpt_generator.py
@@ -1,0 +1,43 @@
+import os
+import requests
+
+
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
+DEEPSEEK_URL = os.getenv(
+    "DEEPSEEK_URL",
+    "https://api.deepseek.com/v1/chat/completions",
+)
+
+
+def generate_email(
+    name: str,
+    firm: str,
+    city: str,
+    template_path: str = "templates/lawyer_email.txt",
+) -> str:
+    with open(template_path, "r", encoding="utf-8") as f:
+        template = f.read()
+
+    prompt = (
+        template.replace("{{name}}", name)
+        .replace("{{firm}}", firm)
+        .replace("{{city}}", city)
+    )
+
+    payload = {
+        "model": "deepseek-chat",
+        "temperature": 0.7,
+        "max_tokens": 300,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Rewrite the following email to sound natural and personalized.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    }
+    headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
+    resp = requests.post(DEEPSEEK_URL, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"].strip()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,57 @@
+import os
+import csv
+import time
+from scraper import scrape_contacts
+from gpt_generator import generate_email
+from email_sender import send_email
+
+
+CITIES = [
+    "Toronto",
+    "Ottawa",
+    "Hamilton",
+    "London",
+    "Windsor",
+]
+
+
+def load_contacts(path: str = "lawyers.csv") -> list[dict]:
+    if not os.path.exists(path):
+        return []
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def load_sent(path: str = "sent.csv") -> set[str]:
+    if not os.path.exists(path):
+        return set()
+    with open(path, newline="", encoding="utf-8") as f:
+        return {row["email"] for row in csv.DictReader(f, fieldnames=["email"])}
+
+
+def append_sent(email: str, path: str = "sent.csv") -> None:
+    exists = os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["email"])
+        if not exists:
+            writer.writeheader()
+        writer.writerow({"email": email})
+
+
+def main() -> None:
+    if not os.path.exists("lawyers.csv"):
+        scrape_contacts(CITIES)
+    contacts = load_contacts()
+    sent = load_sent()
+    for contact in contacts:
+        email = contact["email"]
+        if email in sent:
+            continue
+        body = generate_email(contact["name"], contact["firm"], contact["city"])
+        send_email(email, body)
+        append_sent(email)
+        time.sleep(20)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,64 @@
+import csv
+import os
+import re
+import requests
+from bs4 import BeautifulSoup
+
+SERP_API_KEY = os.getenv("SERPAPI_KEY")
+SERP_URL = "https://serpapi.com/search"
+
+
+def fetch_lawyers(city: str):
+    params = {
+        "engine": "google_maps",
+        "q": "personal injury lawyer",
+        "type": "search",
+        "google_domain": "google.ca",
+        "hl": "en",
+        "gl": "ca",
+        "location": f"{city}, Ontario",
+        "api_key": SERP_API_KEY,
+    }
+    resp = requests.get(SERP_URL, params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("places_results", [])
+
+
+def scrape_email(url: str) -> str | None:
+    try:
+        resp = requests.get(url, timeout=10)
+    except Exception:
+        return None
+    if not resp.ok:
+        return None
+    soup = BeautifulSoup(resp.text, "html.parser")
+    email_re = re.compile(r"[a-zA-Z0-9.+_-]+@[a-zA-Z0-9._-]+\.[a-zA-Z]+")
+    match = email_re.search(soup.get_text())
+    if match:
+        return match.group(0)
+    return None
+
+
+def scrape_contacts(cities: list[str], outfile: str = "lawyers.csv") -> None:
+    fieldnames = ["name", "firm", "email", "city", "website"]
+    with open(outfile, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for city in cities:
+            for place in fetch_lawyers(city):
+                website = place.get("website")
+                if not website:
+                    continue
+                email = scrape_email(website)
+                if not email:
+                    continue
+                writer.writerow(
+                    {
+                        "name": place.get("title", ""),
+                        "firm": place.get("title", ""),
+                        "email": email,
+                        "city": city,
+                        "website": website,
+                    }
+                )

--- a/templates/lawyer_email.txt
+++ b/templates/lawyer_email.txt
@@ -1,0 +1,8 @@
+Hello {{name}},
+
+I'm reaching out from Painsnap.tech because we help clients find the right legal representation after an accident. We often hear from injured people in {{city}}, and I thought your firm, {{firm}}, might be interested in additional client referrals.
+
+Let me know if you'd like to learn more.
+
+Best,
+The Painsnap Team


### PR DESCRIPTION
## Summary
- automate lawyer outreach via scraper, GPT email generation and Gmail send
- add environment variable template and ignore outputs
- document usage in README
- switch email generation from ChatGPT to DeepSeek

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a80234c88331b27ada81b24fdd0d